### PR TITLE
mido: Restore better load balancing on boot

### DIFF
--- a/rootdir/etc/init.target.rc
+++ b/rootdir/etc/init.target.rc
@@ -179,6 +179,13 @@ on charger
     start thermal-engine
 
 on boot
+# Update cpusets on boot and we want better load balancing
+    write /dev/cpuset/top-app/cpus 0-7
+    write /dev/cpuset/foreground/cpus 0-6
+    write /dev/cpuset/background/cpus 0-1
+    write /dev/cpuset/system-background/cpus 0-3
+    write /dev/cpuset/restricted/cpus 0-3
+
 # access permission for wlan
     chown system system /mnt/vendor/persist/WCNSS_qcom_wlan_nv.bin
 


### PR DESCRIPTION
As it turned out, allowing background, system-background, restricted,
foreground and top-app to use all 8 cores results in severe jitter and lag
whenever background tasks are running, whether it be on boot, or during waking up
from sleep.

This commit readds pinning background to cores 0-1, system-background and
restricted to cores 0-3, foreground to cores 0-6 and top-app to cores 0-7.

Change-Id: Idb76879e75e05b437600f0b689c260c674eb7eea

Co-authored-by: Zile995 <stefan.zivkovic995@gmail.com>