### PR TITLE
init.qcom.rc: Let the kernel handle the i/o scheduler. 

### DIFF
--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -523,6 +523,3 @@ service vendor.power_off_alarm /vendor/bin/power_off_alarm
     group system
     disabled
     oneshot
-
-on property:dev.bootcomplete=1
-    setprop sys.io.scheduler "bfq"


### PR DESCRIPTION
This commit is causing issues with custom kernels applying the desired i/o scheduler.