### PR TITLE
mido: touch: proper fix

### DIFF
--- a/touch/vendor.lineage.touch@1.0-service.xiaomi_mido.rc
+++ b/touch/vendor.lineage.touch@1.0-service.xiaomi_mido.rc
@@ -1,9 +1,9 @@
-on init
+on boot
     # Key Disabler
     chown system system /proc/touchpanel/capacitive_keys_disable
-    chmod 0666 /proc/touchpanel/capacitive_keys_disable
+    chmod 0660 /proc/touchpanel/capacitive_keys_disable
     chown system system /sys/bus/i2c/devices/3-0038/disable_keys
-    chmod 0666 /sys/bus/i2c/devices/3-0038/disable_keys
+    chmod 0660 /sys/bus/i2c/devices/3-0038/disable_keys
     # Glove Mode
     chown system system /sys/class/tp_glove/device/glove_enable
     chmod 0660 /sys/class/tp_glove/device/glove_enable


### PR DESCRIPTION
Without this commit the changes weren't being applied, so for example the capacitive keys were still working in Lineage (encrypted) even if the navbar was enabled and the backlight was off.
Also changed the permissions to be more restrictive.