### PR TITLE
mido: Set partitions for loop device

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -43,7 +43,7 @@ TARGET_USES_64_BIT_BINDER := true
 # Kernel
 TARGET_KERNEL_CONFIG := mido_defconfig
 BOARD_KERNEL_BASE := 0x80000000
-BOARD_KERNEL_CMDLINE := androidboot.hardware=qcom msm_rtb.filter=0x237 ehci-hcd.park=3 lpm_levels.sleep_disabled=1 androidboot.bootdevice=7824900.sdhci earlycon=msm_hsl_uart,0x78af000
+BOARD_KERNEL_CMDLINE := androidboot.hardware=qcom msm_rtb.filter=0x237 ehci-hcd.park=3 lpm_levels.sleep_disabled=1 androidboot.bootdevice=7824900.sdhci earlycon=msm_hsl_uart,0x78af000 loop.max_part=7
 BOARD_KERNEL_IMAGE_NAME := Image.gz-dtb
 BOARD_KERNEL_PAGESIZE :=  2048
 BOARD_MKBOOTIMG_ARGS := --ramdisk_offset 0x01000000 --tags_offset 0x00000100


### PR DESCRIPTION
AdoptableHostTest in CTS uses virtual disk feature for testing.
This change is to enable partitions for virtual disk.
Change-Id: Ie03766738715ef54d4fa768033a96fdd76d3172b

Signed-off-by: ShihabZzz <Shihab.riadn@gmail.com>