### PR TITLE
mido: Ir/Light: Add Dynamic Lifecycle HAL support

### DIFF
--- a/consumerir/android.hardware.ir@1.0-service.xiaomi_mido.rc
+++ b/consumerir/android.hardware.ir@1.0-service.xiaomi_mido.rc
@@ -1,4 +1,7 @@
 service vendor.ir-hal-1-0 /vendor/bin/hw/android.hardware.ir@1.0-service.xiaomi_mido
+    interface android.hardware.ir@1.0::IConsumerIr default
+    oneshot
+    disabled
     class hal
     user system
     group system

--- a/consumerir/service.cpp
+++ b/consumerir/service.cpp
@@ -17,6 +17,7 @@
 #define LOG_TAG "android.hardware.ir@1.0-service.xiaomi_mido"
 
 #include <android-base/logging.h>
+#include <hidl/HidlLazyUtils.h>
 #include <hidl/HidlTransportSupport.h>
 
 #include "ConsumerIr.h"
@@ -26,6 +27,7 @@ using android::hardware::configureRpcThreadpool;
 using android::hardware::joinRpcThreadpool;
 
 // Generated HIDL files
+using android::hardware::LazyServiceRegistrar;
 using android::hardware::ir::V1_0::IConsumerIr;
 using android::hardware::ir::V1_0::implementation::ConsumerIr;
 
@@ -34,7 +36,10 @@ int main() {
 
     configureRpcThreadpool(1, true /*callerWillJoin*/);
 
-    android::status_t status = service->registerAsService();
+    android::status_t status;
+    auto serviceRegistrar = std::make_shared<LazyServiceRegistrar>();
+    status = serviceRegistrar->registerService(service);
+
     if (status != android::OK) {
         LOG(ERROR) << "Cannot register ConsumerIr HAL service";
         return 1;

--- a/light/android.hardware.light@2.0-service.xiaomi_mido.rc
+++ b/light/android.hardware.light@2.0-service.xiaomi_mido.rc
@@ -8,6 +8,9 @@ on init
     chown system system /sys/class/leds/blue/brightness
 
 service vendor.light-hal-2-0 /vendor/bin/hw/android.hardware.light@2.0-service.xiaomi_mido
+    interface android.hardware.light@2.0::ILight default
+    oneshot
+    disabled
     class hal
     user system
     group system

--- a/light/service.cpp
+++ b/light/service.cpp
@@ -16,6 +16,7 @@
 
 #define LOG_TAG "android.hardware.light@2.0-service.xiaomi_mido"
 
+#include <hidl/HidlLazyUtils.h>
 #include <hidl/HidlTransportSupport.h>
 
 #include "Light.h"
@@ -23,6 +24,7 @@
 using android::hardware::configureRpcThreadpool;
 using android::hardware::joinRpcThreadpool;
 
+using android::hardware::LazyServiceRegistrar;
 using android::hardware::light::V2_0::ILight;
 using android::hardware::light::V2_0::implementation::Light;
 
@@ -35,7 +37,10 @@ int main() {
 
     configureRpcThreadpool(1, true);
 
-    status_t status = service->registerAsService();
+    android::status_t status;
+    auto serviceRegistrar = std::make_shared<LazyServiceRegistrar>();
+    status = serviceRegistrar->registerService(service);
+
     if (status != OK) {
         ALOGE("Cannot register Light HAL service.");
         return 1;


### PR DESCRIPTION
Ir/Light HAL rarely use in practically. But these HALs always run in background & consume power/resources as well.

Android Q adds a new callback and helper functions to make it easier to make use of dynamic
HALs , which were added in P. Dynamic HALs allow you to start your HAL when needed, and
either exit or reduce resource consumption when it’s not being used.

https://source.android.com/devices/architecture/hal/dynamic-lifecycle

Signed-off-by: ShihabZzz <Shihab.riadn@gmail.com>