### PR TITLE
mido: Ir: Add Dynamic Lifecycle HAL support

### DIFF
--- a/consumerir/android.hardware.ir@1.0-service.xiaomi_mido.rc
+++ b/consumerir/android.hardware.ir@1.0-service.xiaomi_mido.rc
@@ -1,4 +1,7 @@
 service vendor.ir-hal-1-0 /vendor/bin/hw/android.hardware.ir@1.0-service.xiaomi_mido
+    interface android.hardware.ir@1.0::IConsumerIr default
+    oneshot
+    disabled
     class hal
     user system
     group system

--- a/consumerir/service.cpp
+++ b/consumerir/service.cpp
@@ -17,6 +17,7 @@
 #define LOG_TAG "android.hardware.ir@1.0-service.xiaomi_mido"
 
 #include <android-base/logging.h>
+#include <hidl/HidlLazyUtils.h>
 #include <hidl/HidlTransportSupport.h>
 
 #include "ConsumerIr.h"
@@ -26,6 +27,7 @@ using android::hardware::configureRpcThreadpool;
 using android::hardware::joinRpcThreadpool;
 
 // Generated HIDL files
+using android::hardware::LazyServiceRegistrar;
 using android::hardware::ir::V1_0::IConsumerIr;
 using android::hardware::ir::V1_0::implementation::ConsumerIr;
 
@@ -34,7 +36,10 @@ int main() {
 
     configureRpcThreadpool(1, true /*callerWillJoin*/);
 
-    android::status_t status = service->registerAsService();
+    android::status_t status;
+    auto serviceRegistrar = std::make_shared<LazyServiceRegistrar>();
+    status = serviceRegistrar->registerService(service);
+
     if (status != android::OK) {
         LOG(ERROR) << "Cannot register ConsumerIr HAL service";
         return 1;


### PR DESCRIPTION
Ir HAL rarely use in practically. But it's always run in background & 
consume power/resources as well.

Android Q adds a new callback and helper functions to make it easier to 
make use of dynamic
HALs , which were added in P. Dynamic HALs allow you to start your HAL 
when needed, and
either exit or reduce resource consumption when it’s not being used.

https://source.android.com/devices/architecture/hal/dynamic-lifecycle

Signed-off-by: ShihabZzz <Shihab.riadn@gmail.com>