### PR TITLE
mido: fix UI lag in some use cases

### DIFF
--- a/vendor_prop.mk
+++ b/vendor_prop.mk
@@ -88,7 +88,6 @@ debug.enable.sglscale=1 \
 debug.mdpcomp.logs=0 \
 debug.sf.enable_hwc_vds=1 \
 debug.sf.hw=0 \
-debug.sf.latch_unsignaled=1 \
 debug.sf.recomputecrop=0 \
 debug.sf.disable_backpressure=1 \
 dev.pm.dyn_samplingrate=1 \


### PR DESCRIPTION
Fixes UI lag in some Live Wallpapers(e.g. Groove) when side-loading Google Live Wallpapers for msm8953 based devices.

Sourced: 
1. https://github.com/LineageOS/android_device_xiaomi_msm8953-common/commit/3d4186f71aee33556444d88be6d4e3dc0b4df7b5 (Dated 31st Dec 2018)

2. https://review.lineageos.org/c/LineageOS/android_device_xiaomi_msm8953-common/+/237578/2 (Dated 01st Jan 2019)

