### PR TITLE
mido: fix lag in some use-cases

### DIFF
--- a/vendor_prop.mk
+++ b/vendor_prop.mk
@@ -88,7 +88,6 @@ debug.enable.sglscale=1 \
 debug.mdpcomp.logs=0 \
 debug.sf.enable_hwc_vds=1 \
 debug.sf.hw=0 \
-debug.sf.latch_unsignaled=1 \
 debug.sf.recomputecrop=0 \
 debug.sf.disable_backpressure=1 \
 dev.pm.dyn_samplingrate=1 \


### PR DESCRIPTION
Fixes UI lag while using Live Wallpapers (e.g. Groove) by side-loading Google's Live Wallpaper apk on msm8953 based devices.

Original Change-Id: I92aaa4469f6848e4dfff89f3781f31ed527bae2b