### PR TITLE
reset modem restart_level

### DIFF
--- a/rootdir/etc/init.parts.rc
+++ b/rootdir/etc/init.parts.rc
@@ -15,3 +15,6 @@ on property:sys.boot_completed=1
   chmod 0660 /sys/kernel/sound_control/headphone_gain
   chmod 0660 /sys/kernel/sound_control/mic_gain
   chmod 0660 /sys/kernel/sound_control/speaker_gain
+
+# modem subsys error Only restart sysbus instead of system
+   write /sys/devices/platform/soc/4080000.qcom,mss/subsys4/restart_level RELATED


### PR DESCRIPTION
relieve https://github.com/zeelog/android_kernel_xiaomi_mido/issues/4

A similar problem occurs under the CMCC network. When the modem fails, only restart the subsys instead of the system to alleviate this problem.