### PR TITLE
mido: props: fix zygote preforking prop

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -173,4 +173,4 @@ ro.zram.first_wb_delay_mins=180
 ro.zram.periodic_wb_delay_hours=24
 
 # Zygote Preforking
-persist.device.config.runtime_native.usap_pool_enabled=true
+persist.device_config.runtime_native.usap_pool_enabled=true


### PR DESCRIPTION
The correct prop is persist.device_config.runtime_native.usap_pool_enabled, not persist.device.config.runtime_native.usap_pool_enabled